### PR TITLE
Fix grammatical errors and add convenience links for TOS & Privacy 

### DIFF
--- a/src/premium/whitelabel-setup-guide.md
+++ b/src/premium/whitelabel-setup-guide.md
@@ -120,4 +120,7 @@ On the `General Information` tab of the Discord developer portal, you may have n
 
 You can enter our policies here to inform users of how their data may be used.
 
+Terms Of Service: https://ticketsbot.net/terms-of-service
+Privacy Policy: https://ticketsbot.net/privacy
+
 ![Policies](/img/whitelabel/policies.webp)

--- a/src/premium/whitelabel-setup-guide.md
+++ b/src/premium/whitelabel-setup-guide.md
@@ -1,5 +1,5 @@
 # Whitelabel Setup Guide
-Thanks for purchasing whitelabel and support us!
+Thanks for purchasing whitelabel and supporting us!
 
 Please follow this guide **very carefully**, if you skip a single step, nothing will work - you've been warned. The process should not take more than 10 minutes, and will only need to be done once.
 


### PR DESCRIPTION
Fix grammatical errors and add convenience links for TOS & Privacy Policy to the Whitelabel section of https://docs.ticketsbot.net/premium/whitelabel-setup-guide