### PR TITLE
Denoting premium only placeholders

### DIFF
--- a/src/commands/commands.md
+++ b/src/commands/commands.md
@@ -35,8 +35,8 @@
 | /language (language) | Changes the language the bot messages are displayed in |
 | /panel | Provides a link to create a reaction panel for users to open tickets |
 | /premium | Activates premium benefits after purchasing (choose patreon on select menu) |
-| /removeadmin&nbsp;(user_or_role) | Revokes a user's or role's admin priveledges |
-| /removesupport (user_or_role) &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Revokes a user's or role's support representative priviledges |
+| /removeadmin (user_or_role) | Revokes a user's or role's admin priveledges |
+| /removesupport (user_or_role) | Revokes a user's or role's support representative priviledges |
 | /setup auto | Bot will make a very basic configuration (no reaction panels - you'll still want to customize on dashboard) |
 | /setup prefix | Change the prefix used for non slash commands (default is `t!`) **NOTE:** Prefix commands are no longer supported, must use slash commands |
 | /setup welcomemessage | Change the overall welcome message |

--- a/src/dashboard/settings/placeholders.md
+++ b/src/dashboard/settings/placeholders.md
@@ -6,6 +6,9 @@
 ***
 
 ### Built-in
+
+\* = This is a premium feature. Learn more about premium [here](https://ticketsbot.net/premium).
+
 |Placeholder|Description |
 |--|--|
 | %user% | Mentions the user |
@@ -22,9 +25,9 @@
 | %time% | Display the current time |
 | %date% | Display today's date |
 | %datetime% | Display the current date and time |
-| %first_response_time_weekly% | Staff average first response time to tickets this week |
-| %first_response_time_monthly% | Staff average first response time to tickets this month |
-| %first_response_time_all_time% | Staff average first response time to tickets since the beginning |
+| * %first_response_time_weekly% | Staff average first response time to tickets this week |
+| * %first_response_time_monthly% | Staff average first response time to tickets this month |
+| * %first_response_time_all_time% | Staff average first response time to tickets since the beginning |
 | %discord_account_creation_date% | The date and time that the user's Discord account was created |
 | %discord_account_age% | How long ago the user's Discord account was created |
 

--- a/src/miscellaneous/placeholders.md
+++ b/src/miscellaneous/placeholders.md
@@ -6,6 +6,9 @@
 ***
 
 ### Built-in
+
+\* = This is a premium feature. Learn more about premium [here](https://ticketsbot.net/premium).
+
 |Placeholder|Description |
 |--|--|
 | %user% | Mentions the user |
@@ -22,9 +25,9 @@
 | %time% | Display the current time |
 | %date% | Display today's date |
 | %datetime% | Display the current date and time |
-| %first_response_time_weekly% | Staff average first response time to tickets this week |
-| %first_response_time_monthly% | Staff average first response time to tickets this month |
-| %first_response_time_all_time% | Staff average first response time to tickets since the beginning |
+| * %first_response_time_weekly% | Staff average first response time to tickets this week |
+| * %first_response_time_monthly% | Staff average first response time to tickets this month |
+| * %first_response_time_all_time% | Staff average first response time to tickets since the beginning |
 | %discord_account_creation_date% | The date and time that the user's Discord account was created |
 | %discord_account_age% | How long ago the user's Discord account was created |
 

--- a/src/setup/individual.md
+++ b/src/setup/individual.md
@@ -46,10 +46,6 @@ An explanation of ticket limits is available [here](./dashboard.md#ticket-limit)
 
 > **Note:** prefix commands are no longer active! Tickets bot works solely on slash commands! No need to setup a prefix.
 
-~~An explanation of prefixes is available [here](./dashboard.md#prefix). The command `/setup prefix` is used to configure the prefix.~~
-
-~~For example: to change the prefix to `-`, run `/setup prefix -`~~
-
 ### Transcripts
 
 An explanation of transcript channels is available [here](./dashboard.md#transcripts-channel). The command `/setup transcripts` is used to configure the transcripts channel.


### PR DESCRIPTION
## Denoting premium only placeholders and small format fixes for mobile view

---
## This PR:
1. Adds an asterisk and explanation on the `placeholders` pages to denote premium only placeholders.
2. Removes some strike through text about the `prefix` command.
3. Adjusts some spacing issues on the command list to better the mobile view.