### PR TITLE
Adding note in claiming documentation

### DIFF
--- a/src/dashboard/settings/claiming.md
+++ b/src/dashboard/settings/claiming.md
@@ -4,10 +4,12 @@
 
 ---
 
+> **Note:** Channel mode only. Discord does not allow threads to be claimed. For more differences between the two modes, click [here](./thread-mode.md#channel-vs-thread-comparison).
+
 Tickets can be claimed by a staff member, so other staff members cannot also reply to the ticket. The benefit of this is that tickets become less cluttered with many staff members talking at once.
 Alternatively, an admin could claim a ticket to keep the support team from seeing potentially sensitive issues.
 
-Note: Admins will always have access to any claimed ticket, as well as the user who claimed it.
+> **Note:** Those with Administrator permissions in your server will always have access to any claimed ticket, as well as the user who claimed it.
 
 ## Commands Related to Claiming:
 

--- a/src/premium/perks.md
+++ b/src/premium/perks.md
@@ -15,7 +15,7 @@
 | Customise Embed Colour | - | X | X |
 | Live Message Updates on the Dashboard | - | X | X |
 | Send Messages Directly from the Dashboard | - | X | X |
+| Exit Surveys | - | X | X |
 | Customize Bot Name | - | - | X |
 | Customize Bot Avatar | - | - | X |
 | Customize Bot Status | - | - | X |
-| Exit Surveys | - | X | X |


### PR DESCRIPTION
Clarifying that claiming is not available for threads.